### PR TITLE
fix: keep rust help side-effect free

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -36,9 +36,9 @@ jobs:
           BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
           for repo in meta_plugin_protocol meta_core; do
-            if git clone --depth 1 -b "$BRANCH" "https://github.com/harmony-labs/${repo}.git" 2>/dev/null; then
+            if git clone --depth 1 -b "$BRANCH" "https://github.com/gitkb/${repo}.git" 2>/dev/null; then
               echo "Cloned ${repo}@${BRANCH}"
-            elif git clone --depth 1 "https://github.com/harmony-labs/${repo}.git"; then
+            elif git clone --depth 1 "https://github.com/gitkb/${repo}.git"; then
               echo "Branch ${BRANCH} not found for ${repo}; falling back to default branch"
             else
               echo "::error::Failed to clone ${repo}"
@@ -57,7 +57,7 @@ jobs:
           version = "0.1.0"
           edition = "2021"
           license = "MIT"
-          repository = "https://github.com/harmony-labs/meta"
+          repository = "https://github.com/gitkb/meta"
           EOF
 
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
           BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
           for repo in meta_plugin_protocol meta_core; do
-            if git clone --depth 1 -b "$BRANCH" "https://github.com/harmony-labs/${repo}.git" 2>/dev/null; then
+            if git clone --depth 1 -b "$BRANCH" "https://github.com/gitkb/${repo}.git" 2>/dev/null; then
               echo "Cloned ${repo}@${BRANCH}"
-            elif git clone --depth 1 "https://github.com/harmony-labs/${repo}.git"; then
+            elif git clone --depth 1 "https://github.com/gitkb/${repo}.git"; then
               echo "Branch ${BRANCH} not found for ${repo}; falling back to default branch"
             else
               echo "::error::Failed to clone ${repo}"
@@ -53,7 +53,7 @@ jobs:
           version = "0.1.0"
           edition = "2021"
           license = "MIT"
-          repository = "https://github.com/harmony-labs/meta"
+          repository = "https://github.com/gitkb/meta"
           EOF
 
       - name: Install Rust toolchain
@@ -82,9 +82,9 @@ jobs:
           BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
           for repo in meta_plugin_protocol meta_core; do
-            if git clone --depth 1 -b "$BRANCH" "https://github.com/harmony-labs/${repo}.git" 2>/dev/null; then
+            if git clone --depth 1 -b "$BRANCH" "https://github.com/gitkb/${repo}.git" 2>/dev/null; then
               echo "Cloned ${repo}@${BRANCH}"
-            elif git clone --depth 1 "https://github.com/harmony-labs/${repo}.git"; then
+            elif git clone --depth 1 "https://github.com/gitkb/${repo}.git"; then
               echo "Branch ${BRANCH} not found for ${repo}; falling back to default branch"
             else
               echo "::error::Failed to clone ${repo}"
@@ -103,7 +103,7 @@ jobs:
           version = "0.1.0"
           edition = "2021"
           license = "MIT"
-          repository = "https://github.com/harmony-labs/meta"
+          repository = "https://github.com/gitkb/meta"
           EOF
 
       - name: Install Rust toolchain
@@ -134,9 +134,9 @@ jobs:
           BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
           for repo in meta_plugin_protocol meta_core; do
-            if git clone --depth 1 -b "$BRANCH" "https://github.com/harmony-labs/${repo}.git" 2>/dev/null; then
+            if git clone --depth 1 -b "$BRANCH" "https://github.com/gitkb/${repo}.git" 2>/dev/null; then
               echo "Cloned ${repo}@${BRANCH}"
-            elif git clone --depth 1 "https://github.com/harmony-labs/${repo}.git"; then
+            elif git clone --depth 1 "https://github.com/gitkb/${repo}.git"; then
               echo "Branch ${BRANCH} not found for ${repo}; falling back to default branch"
             else
               echo "::error::Failed to clone ${repo}"
@@ -155,7 +155,7 @@ jobs:
           version = "0.1.0"
           edition = "2021"
           license = "MIT"
-          repository = "https://github.com/harmony-labs/meta"
+          repository = "https://github.com/gitkb/meta"
           EOF
 
       - name: Install Rust toolchain

--- a/.github/workflows/notify-parent.yml
+++ b/.github/workflows/notify-parent.yml
@@ -12,11 +12,11 @@ jobs:
     steps:
       - name: Notify parent repo
         # PARENT_REPO_PAT requires `repo` scope (or fine-grained `contents:write`)
-        # on harmony-labs/meta. Configure in Settings → Secrets → Actions.
+        # on gitkb/meta. Configure in Settings → Secrets → Actions.
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
         with:
           token: ${{ secrets.PARENT_REPO_PAT }}
-          repository: harmony-labs/meta
+          repository: gitkb/meta
           event-type: child-repo-updated
           client-payload: >-
             {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,11 @@ pub fn execute_command(
     cwd: &Path,
 ) -> CommandResult {
     // Intercept --help/-h before dispatching to subcommand handlers
-    if args.iter().any(|a| a == "--help" || a == "-h") {
+    if command
+        .split_whitespace()
+        .chain(args.iter().map(String::as_str))
+        .any(|a| a == "--help" || a == "-h")
+    {
         return CommandResult::ShowHelp(None);
     }
 
@@ -81,7 +85,7 @@ pub fn execute_command(
 
     // Build the cargo command
     let cargo_cmd = match command {
-        "cargo build" => {
+        "cargo build" | "rust build" => {
             let mut cmd = "cargo build".to_string();
             for arg in args {
                 cmd.push(' ');
@@ -89,7 +93,7 @@ pub fn execute_command(
             }
             cmd
         }
-        "cargo test" => {
+        "cargo test" | "rust test" => {
             let mut cmd = "cargo test".to_string();
             for arg in args {
                 cmd.push(' ');

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,15 +21,22 @@ fn main() {
         info: PluginInfo {
             name: "rust".to_string(),
             version: env!("CARGO_PKG_VERSION").to_string(),
-            commands: vec!["cargo build".to_string(), "cargo test".to_string()],
+            commands: vec![
+                "cargo build".to_string(),
+                "cargo test".to_string(),
+                "rust build".to_string(),
+                "rust test".to_string(),
+            ],
             description: Some("Rust/Cargo commands for meta repositories".to_string()),
             help: Some(PluginHelp {
-                usage: "meta cargo <command> [args...]".to_string(),
+                usage: "meta cargo <command> [args...]\n       meta rust <command> [args...]"
+                    .to_string(),
                 commands: help_commands,
                 command_sections: IndexMap::new(),
                 examples: vec![
                     "meta cargo build".to_string(),
                     "meta cargo test".to_string(),
+                    "meta rust build".to_string(),
                     "meta cargo build --release".to_string(),
                 ],
                 note: Some("To run raw cargo commands: meta exec -- cargo <command>".to_string()),


### PR DESCRIPTION
## Summary
- advertise `rust build/test` as aliases alongside `cargo build/test`
- make rust/cargo child help use the simple plugin help path without workspace discovery
- preserve the cargo command execution mapping for the rust alias

## Verification
- cargo fmt --all
- cargo test -q --workspace
- cargo build --workspace --quiet
- bats tests/help.bats

Implements [[tasks/harmony-677]]